### PR TITLE
Accessible keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import 'auto-complete-element'
 ```html
 <auto-complete src="/users/search" aria-owns="users-popup">
   <input type="text" data-autocomplete-autofocus>
-  <ul slot="popup" id="users-popup"></ul>
+  <ul id="users-popup"></ul>
 </auto-complete>
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@ import 'auto-complete-element'
 ```
 
 ```html
-<auto-complete src="/users/search">
+<auto-complete src="/users/search" aria-owns="users-popup">
   <input slot="field" type="text" data-autocomplete-autofocus>
-  <div slot="popup">
-    <ul slot="results"></ul>
-  </div>
+  <ul slot="popup" id="users-popup"></ul>
 </auto-complete>
+```
+
+The server response should include the items that matched the search query.
+
+```html
+<li role="option" data-autocomplete-value="@hubot">Hubot</li>
+<li role="option" data-autocomplete-value="@bender">Bender</li>
+<li role="option" data-autocomplete-value="@bb-8">BB-8</li>
+<li role="option" data-autocomplete-value="@r2d2" aria-disabled="true">R2-D2 (powered down)</li>
 ```
 
 ## Browser support

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import 'auto-complete-element'
 
 ```html
 <auto-complete src="/users/search" aria-owns="users-popup">
-  <input slot="field" type="text" data-autocomplete-autofocus>
+  <input type="text" data-autocomplete-autofocus>
   <ul slot="popup" id="users-popup"></ul>
 </auto-complete>
 ```

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,10 +25,10 @@
         send() {
           this.status = 200
           this.responseText = `
-            <li role="option" data-autocomplete-value="one">Hubot</li>
-            <li role="option" data-autocomplete-value="two">Bender</li>
-            <li role="option" data-autocomplete-value="three">BB-8</li>
-            <li role="option" data-autocomplete-value="four" aria-disabled="true">R2-D2 (powered down)</li>
+            <li role="option" data-autocomplete-value="@hubot">Hubot</li>
+            <li role="option" data-autocomplete-value="@bender">Bender</li>
+            <li role="option" data-autocomplete-value="@bb-8">BB-8</li>
+            <li role="option" data-autocomplete-value="@r2d2" aria-disabled="true">R2-D2 (powered down)</li>
           `
           setTimeout(this.onload.bind(this), 0)
         }
@@ -41,10 +41,7 @@
     <label id="robots-label">Robots</label>
     <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
       <input type="text" slot="field" aria-labelledby="robots-label" autofocus>
-      <div slot="popup" id="items-popup" aria-labelledby="robots-label">
-        <ul slot="results">
-        </ul>
-      </div>
+      <ul slot="popup" id="items-popup" aria-labelledby="robots-label"></ul>
     </auto-complete>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,11 @@
 <html>
   <head>
     <title>Auto-complete examples</title>
+    <style>
+      auto-complete [aria-selected="true"] {
+        background-color: lavender;
+      }
+    </style>
     <script>
       class FakeXMLHttpRequest {
         open(method, url) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,8 @@
   <head>
     <title>Auto-complete examples</title>
     <style>
-      auto-complete [aria-selected="true"] {
+      auto-complete [aria-selected="true"],
+      auto-complete [role="option"]:hover {
         background-color: lavender;
       }
     </style>

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,6 +7,9 @@
       auto-complete [role="option"]:hover {
         background-color: lavender;
       }
+      auto-complete [aria-disabled="true"] {
+        color: grey;
+      }
     </style>
     <script>
       class FakeXMLHttpRequest {
@@ -22,6 +25,7 @@
             <li role="option" data-autocomplete-value="one">Hubot</li>
             <li role="option" data-autocomplete-value="two">Bender</li>
             <li role="option" data-autocomplete-value="three">BB-8</li>
+            <li role="option" data-autocomplete-value="four" aria-disabled="true">R2-D2 (powered down)</li>
           `
           setTimeout(this.onload.bind(this), 0)
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,7 +40,7 @@
   <body>
     <label id="robots-label">Robots</label>
     <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
-      <input type="text" slot="field" aria-labelledby="robots-label" autofocus>
+      <input type="text" aria-labelledby="robots-label" autofocus>
       <ul slot="popup" id="items-popup" aria-labelledby="robots-label"></ul>
     </auto-complete>
   </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -41,7 +41,7 @@
     <label id="robots-label">Robots</label>
     <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
       <input type="text" aria-labelledby="robots-label" autofocus>
-      <ul slot="popup" id="items-popup" aria-labelledby="robots-label"></ul>
+      <ul id="items-popup" aria-labelledby="robots-label"></ul>
     </auto-complete>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,9 +13,9 @@
         send() {
           this.status = 200
           this.responseText = `
-            <li data-autocomplete-value="one">Hubot</li>
-            <li data-autocomplete-value="two">Bender</li>
-            <li data-autocomplete-value="three">BB-8</li>
+            <li role="option" data-autocomplete-value="one">Hubot</li>
+            <li role="option" data-autocomplete-value="two">Bender</li>
+            <li role="option" data-autocomplete-value="three">BB-8</li>
           `
           setTimeout(this.onload.bind(this), 0)
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,9 @@
     </style>
     <script>
       class FakeXMLHttpRequest {
+        abort() {
+          // Do nothing.
+        }
         open(method, url) {
           // Do nothing.
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Auto-complete examples</title>
+    <script>
+      class FakeXMLHttpRequest {
+        open(method, url) {
+          // Do nothing.
+        }
+        setRequestHeader(name, value) {
+          // Do nothing.
+        }
+        send() {
+          this.status = 200
+          this.responseText = `
+            <li data-autocomplete-value="one">Hubot</li>
+            <li data-autocomplete-value="two">Bender</li>
+            <li data-autocomplete-value="three">BB-8</li>
+          `
+          setTimeout(this.onload.bind(this), 0)
+        }
+      }
+      window.XMLHttpRequest = FakeXMLHttpRequest
+    </script>
+    <script src="../dist/index.umd.js"></script>
+  </head>
+  <body>
+    <auto-complete src="/demo" aria-owns="items-popup">
+      <input type="text" slot="field" autofocus>
+      <div slot="popup" id="items-popup">
+        <ul slot="results">
+        </ul>
+      </div>
+    </auto-complete>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,9 +25,10 @@
     <script src="../dist/index.umd.js"></script>
   </head>
   <body>
-    <auto-complete src="/demo" aria-owns="items-popup">
-      <input type="text" slot="field" autofocus>
-      <div slot="popup" id="items-popup">
+    <label id="robots-label">Robots</label>
+    <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
+      <input type="text" slot="field" aria-labelledby="robots-label" autofocus>
+      <div slot="popup" id="items-popup" aria-labelledby="robots-label">
         <ul slot="results">
         </ul>
       </div>

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -12,9 +12,8 @@ export default class AutocompleteElement extends HTMLElement {
   connectedCallback() {
     const input = this.querySelector('input[slot="field"]')
     const results = this.querySelector('[slot="popup"]')
-    const list = this.querySelector('[slot="results"]')
-    if (!(input instanceof HTMLInputElement) || !results || !list) return
-    state.set(this, new Autocomplete(this, input, results, list))
+    if (!(input instanceof HTMLInputElement) || !results) return
+    state.set(this, new Autocomplete(this, input, results))
 
     this.setAttribute('role', 'combobox')
     this.setAttribute('aria-haspopup', 'listbox')

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -10,8 +10,11 @@ export default class AutocompleteElement extends HTMLElement {
   }
 
   connectedCallback() {
+    const owns = this.getAttribute('aria-owns')
+    if (!owns) return
+
     const input = this.querySelector('input')
-    const results = this.querySelector('[slot="popup"]')
+    const results = document.getElementById(owns)
     if (!(input instanceof HTMLInputElement) || !results) return
     state.set(this, new Autocomplete(this, input, results))
 
@@ -19,9 +22,8 @@ export default class AutocompleteElement extends HTMLElement {
     this.setAttribute('aria-haspopup', 'listbox')
     this.setAttribute('aria-expanded', 'false')
 
-    const popup = this.getAttribute('aria-owns') || ''
     input.setAttribute('aria-autocomplete', 'list')
-    input.setAttribute('aria-controls', popup)
+    input.setAttribute('aria-controls', owns)
 
     results.setAttribute('role', 'listbox')
   }

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -15,6 +15,16 @@ export default class AutocompleteElement extends HTMLElement {
     const list = this.querySelector('[slot="results"]')
     if (!(input instanceof HTMLInputElement) || !results || !list) return
     state.set(this, new Autocomplete(this, input, results, list))
+
+    this.setAttribute('role', 'combobox')
+    this.setAttribute('aria-haspopup', 'listbox')
+    this.setAttribute('aria-expanded', 'false')
+
+    const popup = this.getAttribute('aria-owns') || ''
+    input.setAttribute('aria-autocomplete', 'list')
+    input.setAttribute('aria-controls', popup)
+
+    results.setAttribute('role', 'listbox')
   }
 
   disconnectedCallback() {

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -10,7 +10,7 @@ export default class AutocompleteElement extends HTMLElement {
   }
 
   connectedCallback() {
-    const input = this.querySelector('input[slot="field"]')
+    const input = this.querySelector('input')
     const results = this.querySelector('[slot="popup"]')
     if (!(input instanceof HTMLInputElement) || !results) return
     state.set(this, new Autocomplete(this, input, results))

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -3,6 +3,7 @@
 import type AutocompleteElement from './auto-complete-element'
 import debounce from './debounce'
 import {fragment} from './send'
+import {scrollTo} from './scroll'
 
 const ctrlBindings = navigator.userAgent.match(/Macintosh/)
 
@@ -55,7 +56,7 @@ export default class Autocomplete {
     this.results.removeEventListener('click', this.onResultsClick)
   }
 
-  sibling(next: boolean): Element {
+  sibling(next: boolean): HTMLElement {
     const options = Array.from(this.results.querySelectorAll('[role="option"]'))
     const selected = this.results.querySelector('[aria-selected="true"]')
     const index = options.indexOf(selected)
@@ -64,12 +65,13 @@ export default class Autocomplete {
     return sibling || def
   }
 
-  select(target: Element) {
+  select(target: HTMLElement) {
     for (const el of this.results.querySelectorAll('[aria-selected="true"]')) {
       el.removeAttribute('aria-selected')
     }
     target.setAttribute('aria-selected', 'true')
     this.input.setAttribute('aria-activedescendant', target.id)
+    scrollTo(this.results, target)
   }
 
   onKeydown(event: KeyboardEvent) {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -116,7 +116,7 @@ export default class Autocomplete {
   close() {
     if (this.results.hidden) return
     this.results.hidden = true
-    this.container.setAttribute('aria-expanded', 'true')
+    this.container.setAttribute('aria-expanded', 'false')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }
 }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -8,7 +8,6 @@ export default class Autocomplete {
   container: AutocompleteElement
   input: HTMLInputElement
   results: HTMLElement
-  list: HTMLElement
 
   onInputChange: Function
   onResultsClick: Function
@@ -19,11 +18,10 @@ export default class Autocomplete {
 
   mouseDown: boolean
 
-  constructor(container: AutocompleteElement, input: HTMLInputElement, results: HTMLElement, list: HTMLElement) {
+  constructor(container: AutocompleteElement, input: HTMLInputElement, results: HTMLElement) {
     this.container = container
     this.input = input
     this.results = results
-    this.list = list
 
     this.results.hidden = true
     this.input.setAttribute('autocomplete', 'off')
@@ -56,8 +54,8 @@ export default class Autocomplete {
   }
 
   sibling(next: boolean): Element {
-    const options = Array.from(this.list.querySelectorAll('[role="option"]'))
-    const selected = this.list.querySelector('[aria-selected="true"]')
+    const options = Array.from(this.results.querySelectorAll('[role="option"]'))
+    const selected = this.results.querySelector('[aria-selected="true"]')
     const index = options.indexOf(selected)
     const sibling = next ? options[index + 1] : options[index - 1]
     const def = next ? options[0] : options[options.length - 1]
@@ -65,7 +63,7 @@ export default class Autocomplete {
   }
 
   select(target: Element) {
-    for (const el of this.list.querySelectorAll('[aria-selected="true"]')) {
+    for (const el of this.results.querySelectorAll('[aria-selected="true"]')) {
       el.removeAttribute('aria-selected')
     }
     target.setAttribute('aria-selected', 'true')
@@ -99,7 +97,7 @@ export default class Autocomplete {
         break
       case 'Enter':
         {
-          const selected = this.list.querySelector('[aria-selected="true"]')
+          const selected = this.results.querySelector('[aria-selected="true"]')
           if (selected) {
             this.commit(selected)
             event.preventDefault()
@@ -159,7 +157,7 @@ export default class Autocomplete {
     this.container.dispatchEvent(new CustomEvent('loadstart'))
     fragment(this.input, url.toString())
       .then(html => {
-        this.list.innerHTML = html
+        this.results.innerHTML = html
         const hasResults = !!this.results.querySelector('[data-autocomplete-value]')
         this.container.open = hasResults
         this.container.dispatchEvent(new CustomEvent('load'))

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -109,12 +109,14 @@ export default class Autocomplete {
   open() {
     if (!this.results.hidden) return
     positionBelow(this.input, this.results)
+    this.container.setAttribute('aria-expanded', 'true')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }
 
   close() {
     if (this.results.hidden) return
     this.results.hidden = true
+    this.container.setAttribute('aria-expanded', 'true')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }
 }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -119,6 +119,7 @@ export default class Autocomplete {
   }
 
   commit(selected: Element) {
+    if (selected.getAttribute('aria-disabled') === 'true') return
     const value = selected.getAttribute('data-autocomplete-value') || selected.textContent
     this.container.value = value
     this.container.open = false

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -51,9 +51,43 @@ export default class Autocomplete {
     this.results.removeEventListener('mousedown', this.onResultsMouseDown)
   }
 
+  sibling(next: boolean): Element {
+    const options = Array.from(this.list.querySelectorAll('[role="option"]'))
+    const selected = this.list.querySelector('[aria-selected="true"]')
+    const index = options.indexOf(selected)
+    const sibling = next ? options[index + 1] : options[index - 1]
+    const def = next ? options[0] : options[options.length - 1]
+    return sibling || def
+  }
+
+  select(target: Element) {
+    for (const el of this.list.querySelectorAll('[aria-selected="true"]')) {
+      el.removeAttribute('aria-selected')
+    }
+    target.setAttribute('aria-selected', 'true')
+  }
+
   onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      this.container.open = false
+    switch (event.key) {
+      case 'Escape':
+        this.container.open = false
+        break
+      case 'ArrowDown':
+        this.select(this.sibling(true))
+        break
+      case 'ArrowUp':
+        this.select(this.sibling(false))
+        break
+      case 'n':
+        if (event.ctrlKey) {
+          this.select(this.sibling(true))
+        }
+        break
+      case 'p':
+        if (event.ctrlKey) {
+          this.select(this.sibling(false))
+        }
+        break
     }
   }
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -4,6 +4,8 @@ import type AutocompleteElement from './auto-complete-element'
 import debounce from './debounce'
 import {fragment} from './send'
 
+const ctrlBindings = navigator.userAgent.match(/Macintosh/)
+
 export default class Autocomplete {
   container: AutocompleteElement
   input: HTMLInputElement
@@ -85,13 +87,13 @@ export default class Autocomplete {
         event.preventDefault()
         break
       case 'n':
-        if (event.ctrlKey) {
+        if (ctrlBindings && event.ctrlKey) {
           this.select(this.sibling(true))
           event.preventDefault()
         }
         break
       case 'p':
-        if (event.ctrlKey) {
+        if (ctrlBindings && event.ctrlKey) {
           this.select(this.sibling(false))
           event.preventDefault()
         }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -11,6 +11,7 @@ export default class Autocomplete {
   list: HTMLElement
 
   onInputChange: Function
+  onResultsClick: Function
   onResultsMouseDown: Function
   onInputBlur: Function
   onInputFocus: Function
@@ -31,6 +32,7 @@ export default class Autocomplete {
     this.mouseDown = false
 
     this.onInputChange = debounce(this.onInputChange.bind(this), 300)
+    this.onResultsClick = this.onResultsClick.bind(this)
     this.onResultsMouseDown = this.onResultsMouseDown.bind(this)
     this.onInputBlur = this.onInputBlur.bind(this)
     this.onInputFocus = this.onInputFocus.bind(this)
@@ -41,6 +43,7 @@ export default class Autocomplete {
     this.input.addEventListener('blur', this.onInputBlur)
     this.input.addEventListener('input', this.onInputChange)
     this.results.addEventListener('mousedown', this.onResultsMouseDown)
+    this.results.addEventListener('click', this.onResultsClick)
   }
 
   destroy() {
@@ -49,6 +52,7 @@ export default class Autocomplete {
     this.input.removeEventListener('blur', this.onInputBlur)
     this.input.removeEventListener('input', this.onInputChange)
     this.results.removeEventListener('mousedown', this.onResultsMouseDown)
+    this.results.removeEventListener('click', this.onResultsClick)
   }
 
   sibling(next: boolean): Element {
@@ -97,8 +101,7 @@ export default class Autocomplete {
         {
           const selected = this.list.querySelector('[aria-selected="true"]')
           if (selected) {
-            this.container.value = selected.getAttribute('data-autocomplete-value') || ''
-            this.container.open = false
+            this.commit(selected)
             event.preventDefault()
           }
         }
@@ -113,6 +116,18 @@ export default class Autocomplete {
   onInputBlur() {
     if (this.mouseDown) return
     this.container.open = false
+  }
+
+  commit(selected: Element) {
+    const value = selected.getAttribute('data-autocomplete-value') || selected.textContent
+    this.container.value = value
+    this.container.open = false
+  }
+
+  onResultsClick(event: MouseEvent) {
+    if (!(event.target instanceof Element)) return
+    const selected = event.target.closest('[role="option"]')
+    if (selected) this.commit(selected)
   }
 
   onResultsMouseDown() {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -71,21 +71,36 @@ export default class Autocomplete {
     switch (event.key) {
       case 'Escape':
         this.container.open = false
+        event.preventDefault()
         break
       case 'ArrowDown':
         this.select(this.sibling(true))
+        event.preventDefault()
         break
       case 'ArrowUp':
         this.select(this.sibling(false))
+        event.preventDefault()
         break
       case 'n':
         if (event.ctrlKey) {
           this.select(this.sibling(true))
+          event.preventDefault()
         }
         break
       case 'p':
         if (event.ctrlKey) {
           this.select(this.sibling(false))
+          event.preventDefault()
+        }
+        break
+      case 'Enter':
+        {
+          const selected = this.list.querySelector('[aria-selected="true"]')
+          if (selected) {
+            this.container.value = selected.getAttribute('data-autocomplete-value') || ''
+            this.container.open = false
+            event.preventDefault()
+          }
         }
         break
     }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -67,6 +67,7 @@ export default class Autocomplete {
       el.removeAttribute('aria-selected')
     }
     target.setAttribute('aria-selected', 'true')
+    this.input.setAttribute('aria-activedescendant', target.id)
   }
 
   onKeydown(event: KeyboardEvent) {
@@ -139,6 +140,13 @@ export default class Autocomplete {
     this.fetchResults()
   }
 
+  identifyOptions() {
+    let id = 0
+    for (const el of this.results.querySelectorAll('[role="option"]:not([id])')) {
+      el.id = `${this.results.id}-option-${id++}`
+    }
+  }
+
   fetchResults() {
     const query = this.input.value.trim()
     if (!query) {
@@ -158,6 +166,7 @@ export default class Autocomplete {
     fragment(this.input, url.toString())
       .then(html => {
         this.results.innerHTML = html
+        this.identifyOptions()
         const hasResults = !!this.results.querySelector('[data-autocomplete-value]')
         this.container.open = hasResults
         this.container.dispatchEvent(new CustomEvent('load'))
@@ -179,6 +188,7 @@ export default class Autocomplete {
   close() {
     if (this.results.hidden) return
     this.results.hidden = true
+    this.input.removeAttribute('aria-activedescendant')
     this.container.setAttribute('aria-expanded', 'false')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+export function scrollTo(container: HTMLElement, target: HTMLElement) {
+  if (!inViewport(container, target)) {
+    container.scrollTop = target.offsetTop
+  }
+}
+
+function inViewport(container: HTMLElement, element: HTMLElement): boolean {
+  const scrollTop = container.scrollTop
+  const containerBottom = scrollTop + container.clientHeight
+  const top = element.offsetTop
+  const bottom = top + element.clientHeight
+  return top >= scrollTop && bottom <= containerBottom
+}

--- a/test/test.js
+++ b/test/test.js
@@ -17,9 +17,7 @@ describe('auto-complete element', function() {
       container.innerHTML = `
         <auto-complete src="/search">
           <input slot="field" type="text">
-          <div slot="popup">
-            <ul slot="results"></ul>
-          </div>
+          <ul slot="popup"></ul>
         </auto-complete>`
       document.body.append(container)
     })
@@ -30,11 +28,11 @@ describe('auto-complete element', function() {
 
     it('requests html fragment', async function() {
       const input = document.querySelector('input')
-      const results = document.querySelector('[slot="results"]')
+      const popup = document.querySelector('[slot="popup"]')
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
       await sleep(500)
-      assert.equal('hubot', results.textContent)
+      assert.equal('hubot', popup.textContent)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -15,9 +15,9 @@ describe('auto-complete element', function() {
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
-        <auto-complete src="/search">
+        <auto-complete src="/search" aria-owns="popup">
           <input type="text">
-          <ul slot="popup"></ul>
+          <ul id="popup"></ul>
         </auto-complete>`
       document.body.append(container)
     })
@@ -28,7 +28,7 @@ describe('auto-complete element', function() {
 
     it('requests html fragment', async function() {
       const input = document.querySelector('input')
-      const popup = document.querySelector('[slot="popup"]')
+      const popup = document.querySelector('#popup')
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
       await sleep(500)

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ describe('auto-complete element', function() {
       const container = document.createElement('div')
       container.innerHTML = `
         <auto-complete src="/search">
-          <input slot="field" type="text">
+          <input type="text">
           <ul slot="popup"></ul>
         </auto-complete>`
       document.body.append(container)


### PR DESCRIPTION
Using the [ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices/#combobox) as a guide, this branch introduces a combo box relationship between the auto-complete input field and the result list. Testing with VoiceOver, the screen reader now announces each result item while navigating with up and down arrow keys.

This should hopefully be a nice upgrade for our auto-complete behavior, which is currently not announced while navigating list items.