### PR TITLE
Avoid exceptions raised when keyboard shortcuts are used with no results

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -81,22 +81,30 @@ export default class Autocomplete {
         event.preventDefault()
         break
       case 'ArrowDown':
-        this.select(this.sibling(true))
-        event.preventDefault()
+        {
+          const item = this.sibling(true)
+          if (item) this.select(item)
+          event.preventDefault()
+        }
         break
       case 'ArrowUp':
-        this.select(this.sibling(false))
-        event.preventDefault()
+        {
+          const item = this.sibling(false)
+          if (item) this.select(item)
+          event.preventDefault()
+        }
         break
       case 'n':
         if (ctrlBindings && event.ctrlKey) {
-          this.select(this.sibling(true))
+          const item = this.sibling(true)
+          if (item) this.select(item)
           event.preventDefault()
         }
         break
       case 'p':
         if (ctrlBindings && event.ctrlKey) {
-          this.select(this.sibling(false))
+          const item = this.sibling(false)
+          if (item) this.select(item)
           event.preventDefault()
         }
         break

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,7 +1,9 @@
 function completer(request, response, next) {
   if (request.method === 'GET' && request.url.startsWith('/search?q=hub')) {
     response.writeHead(200)
-    response.end('hubot')
+    response.end(`<li role="option" data-autocomplete-value="first"><span>first</span></li>
+                  <li role="option"><span>second</span></li>
+                  <li role="option"><span>third</span></li>`)
     return
   }
   next()

--- a/test/test.js
+++ b/test/test.js
@@ -24,12 +24,59 @@ describe('auto-complete element', function() {
     })
 
     it('requests html fragment', async function() {
-      const input = document.querySelector('input')
-      const popup = document.querySelector('#popup')
-      input.value = 'hub'
-      input.dispatchEvent(new InputEvent('input'))
-      await once(document, 'loadend')
-      assert.equal('hubot', popup.textContent)
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+      const popup = container.querySelector('#popup')
+
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      assert.equal(3, popup.children.length)
+    })
+
+    it('respects arrow keys', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+      const popup = container.querySelector('#popup')
+
+      assert.isFalse(keydown(input, 'ArrowDown'))
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      assert.isNull(popup.querySelector('[aria-selected="true"]'))
+      assert.isFalse(keydown(input, 'ArrowDown'))
+      assert.equal('first', popup.querySelector('[aria-selected="true"]').textContent)
+      assert.isFalse(keydown(input, 'ArrowDown'))
+      assert.equal('second', popup.querySelector('[aria-selected="true"]').textContent)
+      assert.isFalse(keydown(input, 'ArrowUp'))
+      assert.equal('first', popup.querySelector('[aria-selected="true"]').textContent)
+    })
+
+    it('commits on Enter', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      assert.isTrue(keydown(input, 'Enter'))
+      assert.equal('', container.value)
+      assert.isFalse(keydown(input, 'ArrowDown'))
+      assert.isFalse(keydown(input, 'Enter'))
+      assert.equal('first', container.value)
+      assert.isFalse(container.open)
+    })
+
+    it('closes on Escape', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      assert.isTrue(container.open)
+      assert.isFalse(keydown(input, 'Escape'))
+      assert.isFalse(container.open)
     })
   })
 })
@@ -38,4 +85,44 @@ function once(element, eventName) {
   return new Promise(resolve => {
     element.addEventListener(eventName, resolve, {once: true})
   })
+}
+
+function triggerInput(input, value) {
+  input.value = value
+  return input.dispatchEvent(new InputEvent('input'))
+}
+
+const keyCodes = {
+  ArrowDown: 40,
+  ArrowUp: 38,
+  Enter: 13,
+  Escape: 27,
+  Tab: 9
+}
+
+function keydown(element, key) {
+  const e = {
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false
+  }
+
+  key = key.replace(/\b(Ctrl|Alt|Meta)\+/g, function(_, type) {
+    e[`${type}Key`] = true
+    return ''
+  })
+  e.key = key
+  if (key !== key.toLowerCase()) e.shiftKey = true
+  e.keyCode = keyCodes[key] || key.toUpperCase().charCodeAt(0)
+  e.which = e.keyCode
+
+  const event = document.createEvent('Events')
+  event.initEvent('keydown', true, true)
+
+  for (const prop in e) {
+    event[prop] = e[prop]
+  }
+
+  return element.dispatchEvent(event)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -13,17 +13,14 @@ describe('auto-complete element', function() {
 
   describe('requesting server results', function() {
     beforeEach(function() {
-      const container = document.createElement('div')
-      container.innerHTML = `
-        <auto-complete src="/search" aria-owns="popup">
-          <input type="text">
-          <ul id="popup"></ul>
-        </auto-complete>`
-      document.body.append(container)
-    })
-
-    afterEach(function() {
-      document.body.innerHTML = ''
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" aria-owns="popup">
+            <input type="text">
+            <ul id="popup"></ul>
+          </auto-complete>
+        </div>
+      `
     })
 
     it('requests html fragment', async function() {

--- a/test/test.js
+++ b/test/test.js
@@ -28,14 +28,14 @@ describe('auto-complete element', function() {
       const popup = document.querySelector('#popup')
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
-      await sleep(500)
+      await once(document, 'loadend')
       assert.equal('hubot', popup.textContent)
     })
   })
 })
 
-function sleep(millis) {
+function once(element, eventName) {
   return new Promise(resolve => {
-    setTimeout(resolve, millis)
+    element.addEventListener(eventName, resolve, {once: true})
   })
 }


### PR DESCRIPTION
When results are empty (either still loading or there are no `role="option"` elements in the result set), the up/down arrow keys as well as <kbd>ctrl-p/n</kbd> would result in exceptions being thrown.