### PR TITLE
Alleviate hard requirement on `data-autocomplete-value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The server response should include the items that matched the search query.
 <li role="option" aria-disabled="true">R2-D2 (powered down)</li>
 ```
 
-The `data-autocomplete-value` attribute can be used to define the value for a
-result item whose display text needs to be different:
+The `data-autocomplete-value` attribute can be used to define the value for an
+item whose display text needs to be different:
 
 ```html
-<li role="option" data-autocomplete-value="r2d2">R2-D2 (powered down)</li>
+<li role="option" data-autocomplete-value="bb8">BB-8 (astromech)</li>
 ```
 
 ## Browser support

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import '@github/auto-complete-element'
 
 ```html
 <auto-complete src="/users/search" aria-owns="users-popup">
-  <input type="text" data-autocomplete-autofocus>
+  <input type="text">
   <ul id="users-popup"></ul>
 </auto-complete>
 ```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ import '@github/auto-complete-element'
 The server response should include the items that matched the search query.
 
 ```html
-<li role="option" data-autocomplete-value="@hubot">Hubot</li>
-<li role="option" data-autocomplete-value="@bender">Bender</li>
-<li role="option" data-autocomplete-value="@bb-8">BB-8</li>
-<li role="option" data-autocomplete-value="@r2d2" aria-disabled="true">R2-D2 (powered down)</li>
+<li role="option">Hubot</li>
+<li role="option">Bender</li>
+<li role="option">BB-8</li>
+<li role="option" aria-disabled="true">R2-D2 (powered down)</li>
+```
+
+The `data-autocomplete-value` attribute can be used to define the value for a
+result item whose display text needs to be different:
+
+```html
+<li role="option" data-autocomplete-value="r2d2">R2-D2 (powered down)</li>
 ```
 
 ## Browser support

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -179,7 +179,7 @@ export default class Autocomplete {
       .then(html => {
         this.results.innerHTML = html
         this.identifyOptions()
-        const hasResults = !!this.results.querySelector('[data-autocomplete-value]')
+        const hasResults = !!this.results.querySelector('[role="option"]')
         this.container.open = hasResults
         this.container.dispatchEvent(new CustomEvent('load'))
         this.container.dispatchEvent(new CustomEvent('loadend'))


### PR DESCRIPTION
The `data-autocomplete-value` attribute is optional since invididual items fall back to `.textContent` for their values. Instead, check if there are any results by querying elements with `role="option"`, which is depended on elsewhere in the codebase too.