### PR TITLE
Allow relative URLs in `<auto-complete src="...">`

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -169,7 +169,7 @@ export default class Autocomplete {
     const src = this.container.src
     if (!src) return
 
-    const url = new URL(src, window.location.origin)
+    const url = new URL(src, window.location.href)
     const params = new URLSearchParams(url.search.slice(1))
     params.append('q', query)
     url.search = params.toString()


### PR DESCRIPTION
The URLs are now relative to the current document's URL, rather to the domain root. Previously, all relative URLs were effectively treated as absolute.

This also fixes `<auto-complete>` when loaded over `file:` protocol in Firefox, where `location.origin` is `"null"`. This makes our example document work when experimental custom elements technology is enabled in Firefox 61.