### PR TITLE
Fix example in Chrome

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -35,7 +35,6 @@
       }
       window.XMLHttpRequest = FakeXMLHttpRequest
     </script>
-    <script src="../dist/index.umd.js"></script>
   </head>
   <body>
     <label id="robots-label">Robots</label>
@@ -43,5 +42,6 @@
       <input type="text" aria-labelledby="robots-label" autofocus>
       <ul id="items-popup" aria-labelledby="robots-label"></ul>
     </auto-complete>
+    <script src="../dist/index.umd.js"></script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Auto-complete examples</title>
+    <meta charset="utf-8">
     <style>
       auto-complete [aria-selected="true"],
       auto-complete [role="option"]:hover {


### PR DESCRIPTION
When `connectedCallback` runs for `<auto-complete>` element while the document is still parsing, its contents is still unavailable. https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks

It is not clear whether we need to restructure our `connectedCallback` to be more resilient to this case. In the meantime, fix the example document by defining the `auto-complete` element at a time that the document is fully loaded.