### PR TITLE
Allow submit on enter

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -38,11 +38,14 @@
     </script>
   </head>
   <body>
-    <label id="robots-label">Robots</label>
-    <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
-      <input type="text" aria-labelledby="robots-label" autofocus>
-      <ul id="items-popup" aria-labelledby="robots-label"></ul>
-    </auto-complete>
+    <form>
+      <label id="robots-label">Robots</label>
+      <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
+        <input name="robot" type="text" aria-labelledby="robots-label" autofocus>
+        <ul id="items-popup" aria-labelledby="robots-label"></ul>
+      </auto-complete>
+      <button type="submit">Save</button>
+    </form>
     <script src="../dist/index.umd.js"></script>
   </body>
 </html>

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -119,7 +119,7 @@ export default class Autocomplete {
       case 'Enter':
         {
           const selected = this.results.querySelector('[aria-selected="true"]')
-          if (selected) {
+          if (selected && this.container.open) {
             this.commit(selected)
             event.preventDefault()
           }


### PR DESCRIPTION
`event.preventDefault()` prevents users from submitting on `enter` like a normal input could. This changes so we only commit changes & prevent default when container is open.

This however does not change the current behavior where form would be submit-able text is entered but when no results have been selected.

I tried to add a test but I think simulated events can't invoke default actions (form submit in this case) 🤔 .