### PR TITLE
Remove style setting on results container

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -210,6 +210,7 @@ export default class Autocomplete {
 
   open() {
     if (!this.results.hidden) return
+    this.results.hidden = false
     this.container.setAttribute('aria-expanded', 'true')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -210,7 +210,6 @@ export default class Autocomplete {
 
   open() {
     if (!this.results.hidden) return
-    positionBelow(this.input, this.results)
     this.container.setAttribute('aria-expanded', 'true')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }
@@ -222,26 +221,4 @@ export default class Autocomplete {
     this.container.setAttribute('aria-expanded', 'false')
     this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
   }
-}
-
-function positionBelow(input: HTMLInputElement, results: HTMLElement) {
-  const {height, width} = input.getBoundingClientRect()
-
-  results.hidden = false
-  results.style.position = 'absolute'
-  results.style.width = `${width}px`
-
-  const bottom = offsetTop(input) + height
-  setOffset(results, bottom + 5)
-}
-
-function setOffset(element: HTMLElement, top: number) {
-  const curOffset = offsetTop(element)
-  const curTop = parseInt(getComputedStyle(element).top, 10)
-  element.style.top = `${top - curOffset + curTop}px`
-}
-
-function offsetTop(element: HTMLElement): number {
-  const rect = element.getBoundingClientRect()
-  return rect.top + window.pageYOffset
 }

--- a/test/test.js
+++ b/test/test.js
@@ -85,13 +85,16 @@ describe('auto-complete element', function() {
     it('closes on Escape', async function() {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')
+      const popup = container.querySelector('#popup')
 
       triggerInput(input, 'hub')
       await once(container, 'loadend')
 
       assert.isTrue(container.open)
+      assert.isFalse(popup.hidden)
       assert.isFalse(keydown(input, 'Escape'))
       assert.isFalse(container.open)
+      assert.isTrue(popup.hidden)
     })
   })
 })


### PR DESCRIPTION
`<auto-complete>` should not dictate how the results container is styled. 

`.autocomplete-results` works, but we should probably still do a full audit to make sure things look right when we upgrade.

I accidentally removed the `hidden` toggle and turns out the tests didn't check it 🙈 . This PR fixes that too.

cc @kevinsawicki 