### PR TITLE
Add support for fetch-when-blank

### DIFF
--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -64,18 +64,6 @@ export default class AutocompleteElement extends HTMLElement {
     }
   }
 
-  get fetchWhenBlank(): boolean {
-    return this.hasAttribute('fetch-when-blank')
-  }
-
-  set fetchWhenBlank(value: boolean) {
-    if (value) {
-      this.setAttribute('fetch-when-blank', '')
-    } else {
-      this.removeAttribute('fetch-when-blank')
-    }
-  }
-
   static get observedAttributes(): Array<string> {
     return ['open', 'value']
   }

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -64,6 +64,18 @@ export default class AutocompleteElement extends HTMLElement {
     }
   }
 
+  get fetchWhenBlank(): boolean {
+    return this.hasAttribute('fetch-when-blank')
+  }
+
+  set fetchWhenBlank(value: boolean) {
+    if (value) {
+      this.setAttribute('fetch-when-blank', '')
+    } else {
+      this.removeAttribute('fetch-when-blank')
+    }
+  }
+
   static get observedAttributes(): Array<string> {
     return ['open', 'value']
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -179,7 +179,8 @@ export default class Autocomplete {
 
   fetchResults() {
     const query = this.input.value.trim()
-    if (!query) {
+
+    if (!query && !this.container.fetchWhenBlank) {
       this.container.open = false
       return
     }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -180,7 +180,7 @@ export default class Autocomplete {
   fetchResults() {
     const query = this.input.value.trim()
 
-    if (!query && !this.container.fetchWhenBlank) {
+    if (!query && !this.container.hasAttribute('fetch-when-blank')) {
       this.container.open = false
       return
     }

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -9,6 +9,15 @@ function completer(request, response, next) {
     `)
     return
   }
+
+  if (request.method === 'GET' && request.url.startsWith('/search?q=')) {
+    response.writeHead(200)
+    response.end(`
+      <li role="option"><span>first</span></li>
+      <li role="option"><span>second</span></li>
+    `)
+    return
+  }
   next()
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,51 @@ describe('auto-complete element', function() {
     })
   })
 
+  describe('fetch-when-blank', function() {
+    it('makes a request on focus if fetch-when-blank is set', async function() {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" aria-owns="popup" fetch-when-blank>
+            <input type="text">
+            <ul id="popup"></ul>
+          </auto-complete>
+        </div>
+      `
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+      const popup = container.querySelector('#popup')
+
+      input.dispatchEvent(new FocusEvent('focus'))
+      await once(container, 'loadend')
+
+      assert.equal(2, popup.children.length)
+    })
+
+    it('does not fetch on focus if empty and fetch-when-blank is not set', function(done) {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" aria-owns="popup">
+            <input type="text">
+            <ul id="popup"></ul>
+          </auto-complete>
+        </div>
+      `
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      let loadStartCounter = 0
+      container.addEventListener('loadstart', () => {
+        loadStartCounter++
+      })
+
+      input.dispatchEvent(new FocusEvent('focus'))
+      setTimeout(() => {
+        assert.equal(loadStartCounter, 0, 'loadstart is not fired')
+        done()
+      }, 0)
+    })
+  })
+
   describe('requesting server results', function() {
     beforeEach(function() {
       document.body.innerHTML = `


### PR DESCRIPTION
## What?

This PR adds support for a fetch-when-blank attribute: `<auto-complete src="..." fetch-when-blank>`. When set requests to the server will be made, with an empty query parameter, on first focus of an empty input, or after deleting all text in the input. This allows the server to return an initial set of options even before text is typed into the autocomplete.

If used, it is up to the `src` endpoint to return a set of results with an empty query parameter.

## Why?

The primary motivation is that we'd like to move the "add a team" input from a repo page https://github.com/github/customer-feedback/issues/1304 (and probably others) to use auto-complete-element, however we hit a UX roadblock. The current implementation will give you an initial set of results before the user has typed:

<img src="https://user-images.githubusercontent.com/78225/44725936-7ce27180-aace-11e8-8904-0f22c70196c3.png" width=300/>

which is a lot more useful (particularly when the potential list is short) than just an empty input:

![image](https://user-images.githubusercontent.com/78225/44726127-f67a5f80-aace-11e8-918a-1f6022bc6e50.png)

This change brings the auto-complete UX closer to the original:

![image](https://user-images.githubusercontent.com/78225/44726458-acde4480-aacf-11e8-8334-35cfd51e158d.png)

## Questions

- [ ] We had some discussion about whether this param should be something like `fetch-when-blank` which would simply be a boolean, or a more flexible: `query-min-length=number` which would allow the developer to choose how many chars are required before a request will be made (`query-min-length=0` being equivalent to `fetch-when-blank`). I went with `fetch-when-blank` based on @muan's suggestion:

    > Cause minlength would be a hidden constraint that we would need to remember to tell the users, if used flexibly, set to 6 or something.
- [ ] If we're happy with `fetch-when-blank` conceptually, are we actually happy with this specific attribute name?

