### PR TITLE
Prefix auto-complete-change event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ completer.addEventListener('error', function(event) {
 // Auto-complete result events.
 completer.addEventListener('auto-complete-change', function(event) {
   console.log('Auto-completed value chosen or cleared', completer.value)
+  console.log('Related input element', event.detail.relatedTarget)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ completer.addEventListener('error', function(event) {
 completer.addEventListener('auto-complete-change', function(event) {
   console.log('Auto-completed value chosen or cleared', completer.value)
 })
-completer.addEventListener('toggle', function(event) {
+completer.addEventListener('auto-complete-toggle', function(event) {
   console.log('Auto-completion list is now open or closed', completer.open)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ completer.addEventListener('error', function(event) {
 })
 
 // Auto-complete result events.
-completer.addEventListener('change', function(event) {
+completer.addEventListener('auto-complete-change', function(event) {
   console.log('Auto-completed value chosen or cleared', completer.value)
 })
 completer.addEventListener('toggle', function(event) {

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ completer.addEventListener('error', function(event) {
 completer.addEventListener('auto-complete-change', function(event) {
   console.log('Auto-completed value chosen or cleared', completer.value)
 })
-completer.addEventListener('auto-complete-toggle', function(event) {
-  console.log('Auto-completion list is now open or closed', completer.open)
-})
 ```
 
 ## Browser support

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -83,7 +83,14 @@ export default class AutocompleteElement extends HTMLElement {
         if (newValue !== null) {
           autocomplete.input.value = newValue
         }
-        this.dispatchEvent(new CustomEvent('auto-complete-change', {bubbles: true}))
+        this.dispatchEvent(
+          new CustomEvent('auto-complete-change', {
+            bubbles: true,
+            detail: {
+              relatedTarget: autocomplete.input
+            }
+          })
+        )
         break
     }
   }

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -83,7 +83,7 @@ export default class AutocompleteElement extends HTMLElement {
         if (newValue !== null) {
           autocomplete.input.value = newValue
         }
-        this.dispatchEvent(new CustomEvent('change', {bubbles: true}))
+        this.dispatchEvent(new CustomEvent('auto-complete-change', {bubbles: true}))
         break
     }
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -155,7 +155,15 @@ export default class Autocomplete {
     if (!this.results.hidden) return
     this.results.hidden = false
     this.container.setAttribute('aria-expanded', 'true')
-    this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
+    this.container.dispatchEvent(
+      new CustomEvent('auto-complete-toggle', {
+        bubbles: true,
+        detail: {
+          input: this.input,
+          results: this.results
+        }
+      })
+    )
   }
 
   close() {
@@ -163,6 +171,14 @@ export default class Autocomplete {
     this.results.hidden = true
     this.input.removeAttribute('aria-activedescendant')
     this.container.setAttribute('aria-expanded', 'false')
-    this.container.dispatchEvent(new CustomEvent('toggle', {detail: {input: this.input, results: this.results}}))
+    this.container.dispatchEvent(
+      new CustomEvent('auto-complete-toggle', {
+        bubbles: true,
+        detail: {
+          input: this.input,
+          results: this.results
+        }
+      })
+    )
   }
 }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -155,15 +155,6 @@ export default class Autocomplete {
     if (!this.results.hidden) return
     this.results.hidden = false
     this.container.setAttribute('aria-expanded', 'true')
-    this.container.dispatchEvent(
-      new CustomEvent('auto-complete-toggle', {
-        bubbles: true,
-        detail: {
-          input: this.input,
-          results: this.results
-        }
-      })
-    )
   }
 
   close() {
@@ -171,14 +162,5 @@ export default class Autocomplete {
     this.results.hidden = true
     this.input.removeAttribute('aria-activedescendant')
     this.container.setAttribute('aria-expanded', 'false')
-    this.container.dispatchEvent(
-      new CustomEvent('auto-complete-toggle', {
-        bubbles: true,
-        detail: {
-          input: this.input,
-          results: this.results
-        }
-      })
-    )
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,32 @@ describe('auto-complete element', function() {
       assert.equal('first', popup.querySelector('[aria-selected="true"]').textContent)
     })
 
+    it('dispatches change event on commit', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      let value
+      let relatedTarget
+      container.addEventListener(
+        'auto-complete-change',
+        function(event) {
+          value = event.target.value
+          relatedTarget = event.detail.relatedTarget
+        },
+        {once: true}
+      )
+
+      assert.isTrue(keydown(input, 'Enter'))
+      assert.equal('', container.value)
+      assert.isFalse(keydown(input, 'ArrowDown'))
+      assert.isFalse(keydown(input, 'Enter'))
+      assert.equal('first', value)
+      assert.equal(input, relatedTarget)
+    })
+
     it('commits on Enter', async function() {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')


### PR DESCRIPTION
This avoids conflicts with the child input's change event, requiring listeners to test `event.target` to determine which element dispatched the change event.

Removes the `toggle` event because we have no current listeners for it. We can bring it back if needed in the future.