### PR TITLE
Add AutocompleteEvent subclass

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,9 +20,7 @@ export default {
     }
   ],
   plugins: [
-    resolve({
-      main: true
-    }),
+    resolve(),
     babel({
       presets: ['github']
     })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,8 @@ export default {
     {
       file: pkg['main'],
       format: 'umd',
-      name: 'AutocompleteElement'
+      name: 'AutocompleteElement',
+      exports: 'named'
     }
   ],
   plugins: [

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -1,5 +1,6 @@
 /* @flow strict */
 
+import AutocompleteEvent from './auto-complete-event'
 import Autocomplete from './autocomplete'
 
 const state = new WeakMap()
@@ -84,11 +85,9 @@ export default class AutocompleteElement extends HTMLElement {
           autocomplete.input.value = newValue
         }
         this.dispatchEvent(
-          new CustomEvent('auto-complete-change', {
+          new AutocompleteEvent('auto-complete-change', {
             bubbles: true,
-            detail: {
-              relatedTarget: autocomplete.input
-            }
+            relatedTarget: autocomplete.input
           })
         )
         break

--- a/src/auto-complete-event.js
+++ b/src/auto-complete-event.js
@@ -1,0 +1,16 @@
+/* @flow strict */
+
+type AutocompleteEventType = 'auto-complete-change'
+
+type AutocompleteEvent$Init = CustomEvent$Init & {
+  relatedTarget: HTMLInputElement
+}
+
+export default class AutocompleteEvent extends CustomEvent {
+  relatedTarget: HTMLInputElement
+
+  constructor(type: AutocompleteEventType, init: AutocompleteEvent$Init) {
+    super(type, init)
+    this.relatedTarget = init.relatedTarget
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import AutocompleteElement from './auto-complete-element'
 export {AutocompleteElement as default}
+export {default as AutocompleteEvent} from './auto-complete-event'
 
 if (!window.customElements.get('auto-complete')) {
   window.AutocompleteElement = AutocompleteElement

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,14 +1,23 @@
 /* @flow strict */
 
-declare class AutocompleteElement extends HTMLElement {
-  get src(): string;
-  set src(url: string): void;
-  get value(): string;
-  set value(value: string): void;
-  get open(): boolean;
-  set open(value: boolean): void;
-}
+declare module '@github/auto-complete-element' {
+  declare export default class AutocompleteElement extends HTMLElement {
+    get src(): string;
+    set src(url: string): void;
+    get value(): string;
+    set value(value: string): void;
+    get open(): boolean;
+    set open(value: boolean): void;
+  }
 
-declare module 'auto-complete-element' {
-  declare export default typeof AutocompleteElement
+  declare type AutocompleteEventType = 'auto-complete-change'
+
+  declare type AutocompleteEvent$Init = Event$Init & {
+    relatedTarget: HTMLInputElement;
+  }
+
+  declare export class AutocompleteEvent extends CustomEvent {
+    relatedTarget: HTMLInputElement;
+    constructor(type: AutocompleteEventType, init: AutocompleteEvent$Init): void;
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -65,7 +65,7 @@ describe('auto-complete element', function() {
         'auto-complete-change',
         function(event) {
           value = event.target.value
-          relatedTarget = event.detail.relatedTarget
+          relatedTarget = event.relatedTarget
         },
         {once: true}
       )


### PR DESCRIPTION
Allows relatedTarget to be used without null checks and type assertions on the HTMLInputElement. It's guaranteed to be included in the event.