### PR TITLE
Install/uninstall combobox as the results open and close

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -44,8 +44,6 @@ export default class Autocomplete {
     this.input.addEventListener('input', this.onInputChange)
     this.results.addEventListener('mousedown', this.onResultsMouseDown)
     this.results.addEventListener('combobox-commit', this.onCommit)
-
-    installCombobox(this.input, this.results)
   }
 
   destroy() {
@@ -55,8 +53,6 @@ export default class Autocomplete {
     this.input.removeEventListener('input', this.onInputChange)
     this.results.removeEventListener('mousedown', this.onResultsMouseDown)
     this.results.removeEventListener('combobox-commit', this.onCommit)
-
-    uninstallCombobox(this.input, this.results)
   }
 
   sibling(next: boolean): HTMLElement {
@@ -153,12 +149,14 @@ export default class Autocomplete {
 
   open() {
     if (!this.results.hidden) return
+    installCombobox(this.input, this.results)
     this.results.hidden = false
     this.container.setAttribute('aria-expanded', 'true')
   }
 
   close() {
     if (this.results.hidden) return
+    uninstallCombobox(this.input, this.results)
     this.results.hidden = true
     this.input.removeAttribute('aria-activedescendant')
     this.container.setAttribute('aria-expanded', 'false')

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe('auto-complete element', function() {
       const input = container.querySelector('input')
       const popup = container.querySelector('#popup')
 
-      assert.isFalse(keydown(input, 'ArrowDown'))
+      assert.isTrue(keydown(input, 'ArrowDown'))
       triggerInput(input, 'hub')
       await once(container, 'loadend')
 

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,7 @@ describe('auto-complete element', function() {
       assert.isFalse(keydown(input, 'Enter'))
       assert.equal('first', value)
       assert.equal(input, relatedTarget)
+      assert.isTrue(keydown(input, 'Tab'))
     })
 
     it('commits on Enter', async function() {


### PR DESCRIPTION
<kbd>tab</kbd> after `onCommit` doesn't work because `combobox-nav` behavior (unaware of the list's visibility) is still active. This change (un)install `combobox-nav` as the list gets shown/hid. 