### PR TITLE
Fix mouseDown flag not getting reset, which prevents list from closing on blur

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -18,7 +18,7 @@ export default class Autocomplete {
   onKeydown: KeyboardEvent => void
   onCommit: Event => void
 
-  mouseDown: boolean
+  interactingWithList: boolean
 
   constructor(container: AutocompleteElement, input: HTMLInputElement, results: HTMLElement) {
     this.container = container
@@ -29,7 +29,7 @@ export default class Autocomplete {
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('spellcheck', 'false')
 
-    this.mouseDown = false
+    this.interactingWithList = false
 
     this.onInputChange = debounce(this.onInputChange.bind(this), 300)
     this.onResultsMouseDown = this.onResultsMouseDown.bind(this)
@@ -86,8 +86,8 @@ export default class Autocomplete {
   }
 
   onInputBlur() {
-    if (this.mouseDown) {
-      this.mouseDown = false
+    if (this.interactingWithList) {
+      this.interactingWithList = false
       return
     }
     this.container.open = false
@@ -103,7 +103,7 @@ export default class Autocomplete {
   }
 
   onResultsMouseDown() {
-    this.mouseDown = true
+    this.interactingWithList = true
   }
 
   onInputChange() {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -101,7 +101,7 @@ export default class Autocomplete {
 
   onResultsMouseDown() {
     this.mouseDown = true
-    this.results.addEventListener('mouseup', () => (this.mouseDown = false), {once: true})
+    setTimeout(() => (this.mouseDown = false), 100)
   }
 
   onInputChange() {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -86,7 +86,10 @@ export default class Autocomplete {
   }
 
   onInputBlur() {
-    if (this.mouseDown) return
+    if (this.mouseDown) {
+      this.mouseDown = false
+      return
+    }
     this.container.open = false
   }
 
@@ -101,7 +104,6 @@ export default class Autocomplete {
 
   onResultsMouseDown() {
     this.mouseDown = true
-    setTimeout(() => (this.mouseDown = false), 100)
   }
 
   onInputChange() {

--- a/test/test.js
+++ b/test/test.js
@@ -128,6 +128,25 @@ describe('auto-complete element', function() {
       assert.isFalse(container.open)
     })
 
+    it('does not close on blur after mousedown', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      triggerInput(input, 'hub')
+      await once(container, 'loadend')
+
+      const link = container.querySelector('a[role=option]')
+
+      assert.equal('', container.value)
+      link.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+      input.dispatchEvent(new Event('blur'))
+      assert(container.open)
+
+      link.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}))
+      input.dispatchEvent(new Event('blur'))
+      assert.isFalse(container.open)
+    })
+
     it('closes on Escape', async function() {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')

--- a/test/test.js
+++ b/test/test.js
@@ -142,7 +142,7 @@ describe('auto-complete element', function() {
       input.dispatchEvent(new Event('blur'))
       assert(container.open)
 
-      link.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}))
+      await new Promise(resolve => setTimeout(resolve, 100))
       input.dispatchEvent(new Event('blur'))
       assert.isFalse(container.open)
     })


### PR DESCRIPTION
Fixes #18.


| Before | After |
| -- | -- |
| ![](https://cl.ly/629d16039cd1/Screen%252520Recording%2525202019-04-29%252520at%25252010.10.gif) | ![](https://cl.ly/1f7dce17d0f7/Screen%252520Recording%2525202019-04-29%252520at%25252010.11.gif) |


The result list is closed when:

1. Input value is cleared
1. Input is blurred and `mouseDown === false` ⚠️ 
1. Pressing <kbd>Escape</kbd> while focusing on input
1. An option is selected

### Problem

We relied on `mouseup` event to happen on `results` in order to reset `mouseDown` flag, which is what `input.onblur` checks in order to not close results prematurely (before `click`). 

When user drags outside of `results` (likely to avoid click/committing to a wrong option), `mouseup` happens outside of the element – not captured. `mouseDown` stays `true`, and blurring to close (2.) no longer works.

### Solution

Auto reset `mouseDown` flag on timeout instead of relying on `mouseup`. 
