### PR TITLE
Add TS window declaration for AutoCompleteElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,6 @@ export class AutocompleteEvent extends CustomEvent<null> {
 
 declare global {
   interface Window {
-    AutocompleteElement: AutocompleteElement
+    AutocompleteElement: typeof AutocompleteElement
   }
 }


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect this code:

https://github.com/github/auto-complete-element/blob/8a5226805c84bc6c99d48c23c6487b58b4bc0721/src/index.js#L7-L10

This PR adds the declaration of `AutocompleteElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58