### PR TITLE
[Experiment] Implement as form-associated custom element

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -40,13 +40,23 @@
   <body>
     <form>
       <label id="robots-label">Robots</label>
-      <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
-        <input name="robot" type="text" aria-labelledby="robots-label" autofocus>
+      <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label" name="robot_name" required>
+        <input type="text" aria-labelledby="robots-label" autofocus>
         <ul id="items-popup" aria-labelledby="robots-label"></ul>
       </auto-complete>
       <button type="submit">Save</button>
     </form>
     <!-- <script src="../dist/index.umd.js"></script> -->
     <script src="https://unpkg.com/@github/auto-complete-element@latest/dist/index.umd.js"></script>
+    <script>
+      const form = document.querySelector('form')
+      const button = document.querySelector('button')
+      form.addEventListener('reset', disableButton)
+      form.addEventListener('change', disableButton)
+      function disableButton() {
+        button.disabled = !form.checkValidity()
+      }
+      disableButton()
+    </script>
   </body>
 </html>

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -126,6 +126,10 @@ export default class AutocompleteElement extends HTMLElement {
 
     setValidity(this)
   }
+
+  formResetCallback() {
+    this.value = ''
+  }
 }
 
 function setValidity(el) {


### PR DESCRIPTION
Similar to https://github.com/github/image-crop-element/pull/15. [Spec](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example). Enabled by default [since Chrome 77](https://bugs.chromium.org/p/chromium/issues/detail?id=905922), coming soon to [Firefox 72](https://bugzilla.mozilla.org/show_bug.cgi?id=1552313). No progress in [Safari](https://bugs.webkit.org/show_bug.cgi?id=197960) so far.

With this `<autocomplete name value>` becomes a form participant.

This is not meant to be merged yet. Just testing out to see what the future would be. 👀 

cc @github/web-systems-reviewers