### PR TITLE
Replace xhr with fetch

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -1,0 +1,4 @@
+<li role="option" data-autocomplete-value="@hubot">Hubot</li>
+<li role="option" data-autocomplete-value="@bender">Bender</li>
+<li role="option" data-autocomplete-value="@bb-8">BB-8</li>
+<li role="option" data-autocomplete-value="@r2d2" aria-disabled="true">R2-D2 (powered down)</li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,35 +12,11 @@
         color: grey;
       }
     </style>
-    <script>
-      class FakeXMLHttpRequest {
-        abort() {
-          // Do nothing.
-        }
-        open(method, url) {
-          // Do nothing.
-        }
-        setRequestHeader(name, value) {
-          // Do nothing.
-        }
-        send() {
-          this.status = 200
-          this.responseText = `
-            <li role="option" data-autocomplete-value="@hubot">Hubot</li>
-            <li role="option" data-autocomplete-value="@bender">Bender</li>
-            <li role="option" data-autocomplete-value="@bb-8">BB-8</li>
-            <li role="option" data-autocomplete-value="@r2d2" aria-disabled="true">R2-D2 (powered down)</li>
-          `
-          setTimeout(this.onload.bind(this), 0)
-        }
-      }
-      window.XMLHttpRequest = FakeXMLHttpRequest
-    </script>
   </head>
   <body>
     <form>
       <label id="robots-label">Robots</label>
-      <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
+      <auto-complete src="/examples/demo" aria-owns="items-popup" aria-labelledby="robots-label">
         <input name="robot" type="text" aria-labelledby="robots-label" autofocus>
         <ul id="items-popup" aria-labelledby="robots-label"></ul>
       </auto-complete>

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -6,10 +6,6 @@ import Autocomplete from './autocomplete'
 const state = new WeakMap()
 
 export default class AutocompleteElement extends HTMLElement {
-  constructor() {
-    super()
-  }
-
   connectedCallback() {
     const owns = this.getAttribute('aria-owns')
     if (!owns) return

--- a/src/send.js
+++ b/src/send.js
@@ -5,7 +5,6 @@ const requests = new WeakMap()
 export function fragment(el: Element, url: string): Promise<string> {
   const xhr = new XMLHttpRequest()
   xhr.open('GET', url, true)
-  xhr.setRequestHeader('Accept', 'text/html; fragment')
   return request(el, xhr)
 }
 


### PR DESCRIPTION
Best viewed, commit and commit.

Mostly wanted to drop the `text/html; fragment` accept header and did that in 6703c3e. This matches `<auto-check>` which does not check for `text/html; fragment` anymore. Otherwise cleaned up a few things so it's more similar to the work we've done in `<auto-check>`. Using fetch and minor things.