### PR TITLE
Accept `text/fragment+html` as a content-type

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -5,7 +5,7 @@ const requests = new WeakMap()
 export function fragment(el: Element, url: string): Promise<string> {
   const xhr = new XMLHttpRequest()
   xhr.open('GET', url, true)
-  xhr.setRequestHeader('Accept', 'text/html; fragment')
+  xhr.setRequestHeader('Accept', 'text/html; fragment, text/fragment+html')
   return request(el, xhr)
 }
 


### PR DESCRIPTION
Turns out that `text/html; fragment` isn't a valid mimetype which causes some issues with gzip compression in nginx. Changing it to use the extension `fragment` in the `text/html` mimetype should correct this oversight.

This PR adds the `text/fragment+html` mimetype to the accept header rather than straight replacing it so we can migrate github.com without downtime.