### PR TITLE
Remove `text/html; fragment` from accept header

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -5,7 +5,7 @@ const requests = new WeakMap()
 export function fragment(el: Element, url: string): Promise<string> {
   const xhr = new XMLHttpRequest()
   xhr.open('GET', url, true)
-  xhr.setRequestHeader('Accept', 'text/html; fragment, text/fragment+html')
+  xhr.setRequestHeader('Accept', 'text/fragment+html')
   return request(el, xhr)
 }
 


### PR DESCRIPTION
This is a breaking change and would need a major version bump.

Varnish will choke on `;` in a accept header so we need to remove it and only rely on the `text/fragment+html` header.