### PR TITLE
Switch attributes onto input as per spec in ARIA 1.2

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -40,7 +40,7 @@
   <body>
     <form>
       <label id="robots-label">Robots</label>
-      <auto-complete src="/demo" aria-owns="items-popup" aria-labelledby="robots-label">
+      <auto-complete src="/demo" aria-owns="items-popup">
         <input name="robot" type="text" aria-labelledby="robots-label" autofocus>
         <ul id="items-popup" aria-labelledby="robots-label"></ul>
       </auto-complete>

--- a/src/auto-complete-element.js
+++ b/src/auto-complete-element.js
@@ -17,15 +17,13 @@ export default class AutocompleteElement extends HTMLElement {
     const input = this.querySelector('input')
     const results = document.getElementById(owns)
     if (!(input instanceof HTMLInputElement) || !results) return
-    input.setAttribute('aria-owns', owns)
     state.set(this, new Autocomplete(this, input, results))
 
-    this.setAttribute('role', 'combobox')
-    this.setAttribute('aria-haspopup', 'listbox')
-    this.setAttribute('aria-expanded', 'false')
-
-    input.setAttribute('aria-autocomplete', 'list')
+    input.setAttribute('role', 'combobox')
+    input.setAttribute('aria-expanded', 'false')
     input.setAttribute('aria-controls', owns)
+    input.setAttribute('aria-owns', owns)
+    if (!input.hasAttribute('aria-autocomplete')) input.setAttribute('aria-autocomplete', 'list')
 
     results.setAttribute('role', 'listbox')
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -134,7 +134,7 @@ export default class Autocomplete {
     if (!this.results.hidden) return
     installCombobox(this.input, this.results)
     this.results.hidden = false
-    this.container.setAttribute('aria-expanded', 'true')
+    this.input.setAttribute('aria-expanded', 'true')
   }
 
   close() {
@@ -142,6 +142,6 @@ export default class Autocomplete {
     uninstallCombobox(this.input, this.results)
     this.results.hidden = true
     this.input.removeAttribute('aria-activedescendant')
-    this.container.setAttribute('aria-expanded', 'false')
+    this.input.setAttribute('aria-expanded', 'false')
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,18 @@ describe('auto-complete element', function() {
       `
     })
 
+    it('attributes are set', async function() {
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+      const popup = container.querySelector('#popup')
+
+      assert.equal(input.getAttribute('role'), 'combobox')
+      assert.equal(input.getAttribute('aria-autocomplete'), 'list')
+      assert.equal(input.getAttribute('aria-expanded'), 'false')
+      assert.equal(input.getAttribute('aria-controls'), popup.id)
+      assert.equal(input.getAttribute('aria-owns'), popup.id)
+    })
+
     it('requests html fragment', async function() {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')


### PR DESCRIPTION
Ref: https://github.com/github/github/issues/134642

`<auto-complete>` previously follows the combobox pattern prescribed in ARIA 1.1, but turns out that version is poorly supported. This updates the attribute requirements by following [Editable Combobox With List Autocomplete Example](https://www.w3.org/TR/wai-aria-practices-1.2/examples/combobox/combobox-autocomplete-list.html).

Tested with VoiceOver/Safari seems OK. 

@jscholes, @sinabahram: Here's a [test page](https://html-is.glitch.me/github/auto-complete-element-41.html). Note that I've kept `aria-owns` on the wrapper element and the input to avoid breaking public API of the element. If they have a negative effect I can make the breaking change as well.