### PR TITLE
preserve existing autocomplete attribute

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -18,7 +18,9 @@ export default class Autocomplete {
     this.combobox = new Combobox(input, results)
 
     this.results.hidden = true
-    this.input.setAttribute('autocomplete', 'off')
+    if (!this.input.hasAttribute('autocomplete')) {
+      this.input.setAttribute('autocomplete', 'off')
+    }
     this.input.setAttribute('spellcheck', 'false')
 
     this.interactingWithList = false

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,39 @@ describe('auto-complete element', function () {
     })
   })
 
+  describe('element attributes', function () {
+    it('disables input autocomplete and spellcheck', function () {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" for="popup">
+            <input type="text">
+            <ul id="popup"></ul>
+          </auto-complete>
+        </div>
+      `
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      assert.equal('off', input.getAttribute('autocomplete'))
+      assert.equal('false', input.getAttribute('spellcheck'))
+    })
+
+    it('preserves existing autocomplete', function () {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" for="popup">
+            <input type="text" autocomplete="none">
+            <ul id="popup"></ul>
+          </auto-complete>
+        </div>
+      `
+      const container = document.querySelector('auto-complete')
+      const input = container.querySelector('input')
+
+      assert.equal('none', input.getAttribute('autocomplete'))
+    })
+  })
+
   describe('requesting server results', function () {
     beforeEach(function () {
       document.body.innerHTML = `


### PR DESCRIPTION
Chrome ignores `autocomplete="off"`. This PR enables authors to provide their own autocomplete attribute value (eg `autocomplete="none"`) to ensure the browser's autocomplete behavior doesn't take effect.