### PR TITLE
Allow to customize the aria-label attribute of the results container

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -59,7 +59,7 @@ export default class Autocomplete {
     if (!this.results.getAttribute('aria-label')) {
       this.results.setAttribute('aria-label', 'results')
     }
-    
+
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('spellcheck', 'false')
 

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -54,8 +54,12 @@ export default class Autocomplete {
     }
 
     this.results.hidden = true
+
     // @jscholes recommends a generic "results" label as the results are already related to the combobox, which is properly labelled
-    this.results.setAttribute('aria-label', 'results')
+    if (!this.results.getAttribute('aria-label')) {
+      this.results.setAttribute('aria-label', 'results')
+    }
+    
     this.input.setAttribute('autocomplete', 'off')
     this.input.setAttribute('spellcheck', 'false')
 


### PR DESCRIPTION
Currently it is not allowed to customize the aria-label attribute of the results container, since the constructor does not check if an aria-label exists before setting the generic aria-label.

Even if it is appropriate to set "results" in all cases, this prevents translating the labels to other languages.