### PR TITLE
Fixes #38

### DIFF
--- a/src/auto-complete-element.ts
+++ b/src/auto-complete-element.ts
@@ -12,7 +12,7 @@ export default class AutocompleteElement extends HTMLElement {
 
     // eslint-disable-next-line custom-elements/no-dom-traversal-in-connectedcallback
     const input = this.querySelector('input')
-    const results = this.querySelector('#'+listId)
+    const results = this.getRootNode().getElementById(listId)
     if (!(input instanceof HTMLInputElement) || !results) return
     const autoselectEnabled = this.getAttribute('data-autoselect') === 'true'
     state.set(this, new Autocomplete(this, input, results, autoselectEnabled))

--- a/src/auto-complete-element.ts
+++ b/src/auto-complete-element.ts
@@ -8,11 +8,12 @@ const state = new WeakMap()
 export default class AutocompleteElement extends HTMLElement {
   connectedCallback(): void {
     const listId = this.getAttribute('for')
+    if (!this.isConnected) return
     if (!listId) return
 
     // eslint-disable-next-line custom-elements/no-dom-traversal-in-connectedcallback
     const input = this.querySelector('input')
-    const results = this.getRootNode().getElementById(listId)
+    const results = (this.getRootNode() as Document).getElementById(listId)
     if (!(input instanceof HTMLInputElement) || !results) return
     const autoselectEnabled = this.getAttribute('data-autoselect') === 'true'
     state.set(this, new Autocomplete(this, input, results, autoselectEnabled))

--- a/src/auto-complete-element.ts
+++ b/src/auto-complete-element.ts
@@ -12,7 +12,7 @@ export default class AutocompleteElement extends HTMLElement {
 
     // eslint-disable-next-line custom-elements/no-dom-traversal-in-connectedcallback
     const input = this.querySelector('input')
-    const results = document.getElementById(listId)
+    const results = this.querySelector('#'+listId)
     if (!(input instanceof HTMLInputElement) || !results) return
     const autoselectEnabled = this.getAttribute('data-autoselect') === 'true'
     state.set(this, new Autocomplete(this, input, results, autoselectEnabled))

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -28,9 +28,9 @@ export default class Autocomplete {
     this.input = input
     this.results = results
     this.combobox = new Combobox(input, results)
-    this.feedback = document.getElementById(`${this.results.id}-feedback`)
+    this.feedback = container.querySelector(`#${this.results.id}-feedback`)
     this.autoselectEnabled = autoselectEnabled
-    this.clearButton = document.getElementById(`${this.input.id || this.input.name}-clear`)
+    this.clearButton = container.querySelector(`#${this.input.id || this.input.name}-clear`)
 
     // check to see if there are any default options provided
     this.clientOptions = results.querySelectorAll('[role=option]')

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -28,9 +28,9 @@ export default class Autocomplete {
     this.input = input
     this.results = results
     this.combobox = new Combobox(input, results)
-    this.feedback = container.querySelector(`#${this.results.id}-feedback`)
+    this.feedback = container.getRootNode().getElementById(`${this.results.id}-feedback`)
     this.autoselectEnabled = autoselectEnabled
-    this.clearButton = container.querySelector(`#${this.input.id || this.input.name}-clear`)
+    this.clearButton = container.getRootNode().getElementById(`${this.input.id || this.input.name}-clear`)
 
     // check to see if there are any default options provided
     this.clientOptions = results.querySelectorAll('[role=option]')

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -28,9 +28,9 @@ export default class Autocomplete {
     this.input = input
     this.results = results
     this.combobox = new Combobox(input, results)
-    this.feedback = container.getRootNode().getElementById(`${this.results.id}-feedback`)
+    this.feedback = (container.getRootNode() as Document).getElementById(`${this.results.id}-feedback`)
     this.autoselectEnabled = autoselectEnabled
-    this.clearButton = container.getRootNode().getElementById(`${this.input.id || this.input.name}-clear`)
+    this.clearButton = (container.getRootNode() as Document).getElementById(`${this.input.id || this.input.name}-clear`)
 
     // check to see if there are any default options provided
     this.clientOptions = results.querySelectorAll('[role=option]')


### PR DESCRIPTION
Usage of `document.getElementById` causes autocomplete to fail to find needed elements if `auto-complete` is created in javascript or is in the shadowDOM of another element.

This fixes the issue by replacing usage of  `document.getElementById` with `querySellector`.