### PR TITLE
use default option in combobox

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -27,7 +27,9 @@ export default class Autocomplete {
     this.container = container
     this.input = input
     this.results = results
-    this.combobox = new Combobox(input, results)
+    this.combobox = new Combobox(input, results, {
+      defaultFirstOption: autoselectEnabled,
+    })
     this.feedback = (container.getRootNode() as Document).getElementById(`${this.results.id}-feedback`)
     this.autoselectEnabled = autoselectEnabled
     this.clearButton = (container.getRootNode() as Document).getElementById(`${this.input.id || this.input.name}-clear`)
@@ -108,17 +110,6 @@ export default class Autocomplete {
   }
 
   onKeydown(event: KeyboardEvent): void {
-    // if autoselect is enabled, Enter key will select the first option
-    if (event.key === 'Enter' && this.container.open && this.autoselectEnabled) {
-      const firstOption = this.results.children[0]
-      if (firstOption) {
-        event.stopPropagation()
-        event.preventDefault()
-
-        this.onCommit({target: firstOption})
-      }
-    }
-
     if (event.key === 'Escape' && this.container.open) {
       this.container.open = false
       event.stopPropagation()
@@ -212,6 +203,7 @@ export default class Autocomplete {
         // eslint-disable-next-line github/no-inner-html
         this.results.innerHTML = html as string
         this.identifyOptions()
+        this.combobox.indicateDefaultOption()
         const allNewOptions = this.results.querySelectorAll('[role="option"]')
         const hasResults = !!allNewOptions.length
         const numOptions = allNewOptions.length


### PR DESCRIPTION
In #51 we added `data-autoselect` which allows pressing `Enter` to commit the first result, if no others have been selected.

The problem is that with this option, it overrides the behaviour of the combobox events, which causes the first option to _always_ be selected. https://github.com/github/accessibility-audits/issues/4434 has been raised around this issue.


## Steps to reproduce:

1. Visit https://github.github.com/auto-complete-element/examples/
2. Focus the first input
3. Type `bender`
4. With the results displayed, key down until you have selected the `bender` option
5. Press `Enter`

Expected result:

The input is now populated with `@bender`.

Actual result:

The input is populated with `@hubot`.


## Solution

The solution is to use `combox-nav`'s `defaultFirstOption` flag, and calling `indicateFirstOption` when the list is presented. This way `combobox-nav` is in charge of this behaviour, and not this element.