### PR TITLE
Fix issues showing autocomplete results in Firefox

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -46,10 +46,10 @@
         <input name="robot" type="text" aria-labelledby="robots-label" autofocus />
         <!-- if a clear button is passed in, recommended to be *before* UL elements to avoid conflicting with their blur logic -->
         <button id="robot-clear">x</button>
-        <ul popover id="items-popup"></ul>
+        <ul id="items-popup"></ul>
         <!-- For built-in screen-reader announcements:
           - Note the ID is the same as the <ul> with "feedback" appended
-          - Also note that aria attributes will be added programmatically if they aren't set correctly  
+          - Also note that aria attributes will be added programmatically if they aren't set correctly
         -->
         <div id="items-popup-feedback" class="sr-only"></div>
       </auto-complete>
@@ -64,10 +64,10 @@
         <input id="robot-a" name="robot-a" type="text" aria-labelledby="robots-a-label" autofocus />
         <!-- if a clear button is passed in, recommended to be *before* UL elements to avoid conflicting with their blur logic -->
         <button id="robot-a-clear">x</button>
-        <ul popover id="items-a-popup"></ul>
+        <ul id="items-a-popup"></ul>
         <!-- For built-in screen-reader announcements:
           - Note the ID is the same as the <ul> with "feedback" appended
-          - Also note that aria attributes will be added programmatically if they aren't set correctly  
+          - Also note that aria attributes will be added programmatically if they aren't set correctly
         -->
         <div id="items-a-popup-feedback" class="sr-only"></div>
       </auto-complete>
@@ -79,7 +79,7 @@
       <label id="robots-2-label" for="robot-2">Robots (without autoselect on enter)</label>
       <auto-complete src="/demo" for="items-2-popup" aria-labelledby="robots-2-label">
         <input name="robot-2" type="text" aria-labelledby="robots-2-label" autofocus />
-        <ul popover id="items-2-popup"></ul>
+        <ul id="items-2-popup"></ul>
         <div id="items-2-popup-feedback" class="sr-only"></div>
       </auto-complete>
       <button type="submit">Save</button>
@@ -96,7 +96,7 @@
         data-autoselect="true"
       >
         <input name="custom-fetching-robot" type="text" aria-labelledby="custom-fetching-robots-label" autofocus />
-        <ul popover id="custom-fetching-items-popup"></ul>
+        <ul id="custom-fetching-items-popup"></ul>
         <div id="custom-fetching-items-popup-feedback" class="sr-only"></div>
       </auto-complete>
       <button type="submit">Save</button>
@@ -113,7 +113,7 @@
       <auto-complete src="/demo" for="fetch-on-empty-items-popup" aria-labelledby="fetch-on-empty-robots-label" fetch-on-empty>
         <input name="fetch-on-empty-robot" type="text" aria-labelledby="fetch-on-empty-robots-label" autofocus />
         <button id="fetch-on-empty-robot-clear">x</button>
-        <ul popover id="fetch-on-empty-items-popup"></ul>
+        <ul id="fetch-on-empty-items-popup"></ul>
         <div id="fetch-on-empty-items-popup-feedback" class="sr-only"></div>
       </auto-complete>
       <button type="submit">Save</button>

--- a/test/auto-complete-element.js
+++ b/test/auto-complete-element.js
@@ -18,19 +18,8 @@ describe('auto-complete element', function () {
     })
   })
 
-  describe('requesting server results', function () {
-    beforeEach(function () {
-      document.body.innerHTML = `
-        <div id="mocha-fixture">
-          <auto-complete src="/search" for="popup">
-            <input type="text">
-            <ul id="popup"></ul>
-            <div id="popup-feedback"></div>
-          </auto-complete>
-        </div>
-      `
-    })
-
+  // eslint-disable-next-line func-style
+  const serverResponseExamples = function () {
     it('requests html fragment', async function () {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')
@@ -147,25 +136,6 @@ describe('auto-complete element', function () {
       assert.isFalse(container.open)
     })
 
-    it('does not close on blur after mousedown', async function () {
-      const container = document.querySelector('auto-complete')
-      const input = container.querySelector('input')
-
-      triggerInput(input, 'hub')
-      await once(container, 'loadend')
-
-      const link = container.querySelector('a[role=option]')
-
-      assert.equal('', container.value)
-      link.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
-      input.dispatchEvent(new Event('blur'))
-      assert(container.open)
-
-      await sleep(100)
-      input.dispatchEvent(new Event('blur'))
-      assert.isFalse(container.open)
-    })
-
     it('closes on Escape', async function () {
       const container = document.querySelector('auto-complete')
       const input = container.querySelector('input')
@@ -175,10 +145,10 @@ describe('auto-complete element', function () {
       await once(container, 'loadend')
 
       assert.isTrue(container.open)
-      assert.isFalse(popup.hidden)
+      if (!popup.popover) assert.isFalse(popup.hidden)
       assert.isFalse(keydown(input, 'Escape'))
       assert.isFalse(container.open)
-      assert.isTrue(popup.hidden)
+      if (!popup.popover) assert.isTrue(popup.hidden)
     })
 
     it('opens and closes on alt + ArrowDown and alt + ArrowUp', async function () {
@@ -190,15 +160,15 @@ describe('auto-complete element', function () {
       await once(container, 'loadend')
 
       assert.isTrue(container.open)
-      assert.isFalse(popup.hidden)
+      if (!popup.popover) assert.isFalse(popup.hidden)
 
       assert.isFalse(keydown(input, 'ArrowUp', true))
       assert.isFalse(container.open)
-      assert.isTrue(popup.hidden)
+      if (!popup.popover) assert.isTrue(popup.hidden)
 
       assert.isFalse(keydown(input, 'ArrowDown', true))
       assert.isTrue(container.open)
-      assert.isFalse(popup.hidden)
+      if (!popup.popover) assert.isFalse(popup.hidden)
     })
 
     it('allows providing a custom fetch method', async () => {
@@ -216,6 +186,38 @@ describe('auto-complete element', function () {
       assert.equal(2, popup.children.length)
       assert.equal(popup.querySelector('li').textContent, 'Mock Custom Fetch Result 1')
     })
+  }
+
+  describe('requesting server results (non-popover)', function () {
+    beforeEach(function () {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" for="popup">
+            <input type="text">
+            <ul id="popup"></ul>
+            <div id="popup-feedback"></div>
+          </auto-complete>
+        </div>
+      `
+    })
+
+    serverResponseExamples()
+  })
+
+  describe('requesting server results (popover)', function () {
+    beforeEach(function () {
+      document.body.innerHTML = `
+        <div id="mocha-fixture">
+          <auto-complete src="/search" for="popup">
+            <input type="text">
+            <ul popover id="popup"></ul>
+            <div id="popup-feedback"></div>
+          </auto-complete>
+        </div>
+      `
+    })
+
+    serverResponseExamples()
   })
 
   describe('clear button provided', () => {


### PR DESCRIPTION
I ran into an interesting issue last week that was causing weirdness showing autocomplete results that use the popover API:

Before:

https://github.com/github/auto-complete-element/assets/575280/e7baaf78-3ee3-4c30-91f4-4c1f0f760973

After:

https://github.com/github/auto-complete-element/assets/575280/12e70894-2bf9-444a-8ef6-25aed72baa8b

The issue seemed to be that, when a list item was clicked, focus would return to the text input. Focusing the input kicked off a request to fetch results, which displayed the list again. There is already code to handle this case, but it was being applied when the input was focused rather than blurred. This PR inverts the logic for popovers, but keeps it the same for non-popovers. I believe this is because the input's blur event does not fire when a popover appears.