### PR TITLE
Reattach state when child elements change

### DIFF
--- a/src/auto-complete-element.ts
+++ b/src/auto-complete-element.ts
@@ -73,6 +73,12 @@ export class AutoCompleteElement extends HTMLElement {
   connectedCallback(): void {
     if (!this.isConnected) return
     this.#reattachState()
+
+    new MutationObserver(() => {
+      if (!state.get(this)) {
+        this.#reattachState()
+      }
+    }).observe(this, {subtree: true, childList: true})
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
In certain scenarios, most notably Turbo navigation, `<auto-complete>` elements do not respond to events like keypresses and appear to be entirely non-functional. This is because the element relies on certain child elements being present in the DOM when `connectedCallback` fires, an assumption that is not always accurate, i.e. in the Turbo case. This PR adds a mutation observer that triggers a callback when the child elements have loaded. The callback performs the necessary setup that makes the element function normally.