### PR TITLE
Readme Update: `validate` -> `validator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ axe.run(document)
 
 To confirm your usage is working as designed,
 ```js
-import {validate} from '@github/auto-complete-element/validator' 
+import { validator } from '@github/auto-complete-element/validator' 
 
-validate(document)
+const resultObject = validator(document)
 ```
 Passes and failures may be determined by the length of the `passes` and `violations` arrays on the returned object:
 ```js


### PR DESCRIPTION
I couldn't get `validate` to work, I believe because it is (now?) named `validator`. 

Feel free to edit this as you see fit, not use it, write a better commit, whatever you want!